### PR TITLE
Replace the deprecated typeface-lora package with @fontsource/lora and match blaseball.com's font styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,6 +1486,11 @@
         }
       }
     },
+    "@fontsource/lora": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/lora/-/lora-4.5.0.tgz",
+      "integrity": "sha512-4ThGnMFbktlQqsTW7kCdzT888esMFfnbHE9PJMQCtcP2JUIJXDQpxvmtlsio1AJBnvUxPxegAAp76Q8lm7t1VQ=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -13934,11 +13939,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typeface-lora": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-lora/-/typeface-lora-1.1.13.tgz",
-      "integrity": "sha512-Y02iTW9l8PzGWkEVPqFJ4lVfckZHbYB+CZLKb5WsVRWjkKn/wo1X5OwlOwdKr8Tt+HzcgkOzwbdqY6CMgVO0tw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fontsource/lora": "^4.5.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -16,7 +17,6 @@
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "react-toastify": "^7.0.4",
-    "@fontsource/lora": "^4.5.0",
     "uuid": "^8.3.2",
     "web-vitals": "^1.0.1",
     "yarn": "^1.22.10"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "react-toastify": "^7.0.4",
-    "typeface-lora": "^1.1.13",
+    "@fontsource/lora": "^4.5.0",
     "uuid": "^8.3.2",
     "web-vitals": "^1.0.1",
     "yarn": "^1.22.10"

--- a/src/App.css
+++ b/src/App.css
@@ -251,31 +251,37 @@ input[type=checkbox] {
   }
 }
 
-.monitor {
+.bigdeal { /* being -1 */
+  font-weight: 700;
+  font-style: italic;
+  color: var(--font-color);
+}
+
+.shelledone { /* being 0 */
+  color: red;
+  font-weight: 700;
+}
+
+.monitor { /* being 1 */
   color: #5988FF;
   text-shadow: 0 0 20px;
   font-weight: 700;
 }
 
-.reader {
-  color: #A16DC3;
-  text-shadow: 0 0 10px;
-}
-
-.boss {
+.boss { /* being 2 */
   color: var(--boss-color);
   font-weight: 700;
 }
 
-.lootcrates {
-  font-style: italic;
-  color: var(--lootcrates-color);
+.reader { /* being 3 */
+  color: #A16DC3;
+  text-shadow: 0 0 10px;
   font-weight: 700;
 }
 
-.bigdeal {
-  font-weight: 700;
-  color: var(--font-color);
+.lootcrates { /* being 5 */
+  font-style: italic;
+  color: var(--lootcrates-color);
 }
 
 .loadMore {

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -23,6 +23,9 @@ class Entry extends React.PureComponent {
       case -1:
         entryText += " bigdeal";
         break;
+      case 0:
+        entryText += " shelledone";
+        break;
       case 1:
         entryText += " monitor";
         break;

--- a/src/components/filter-select.js
+++ b/src/components/filter-select.js
@@ -143,7 +143,7 @@ const FilterSelect = (props) => {
     {label: "Monitor", value: 1},
     {label: "Coin", value: 2},
     {label: "Reader", value: 3},
-    {label: "Lootcrates", value: 5},
+    {label: "Lōotcrates", value: 5},
   ];
 
   const checkTitle = (opt) => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ import App from './App';
 import { Provider } from 'react-redux';
 import store from './redux/store';
 import Modal from 'react-modal';
-import "typeface-lora";
+// italic styles are intentionally not being imported, to match blaseball.com
+import "@fontsource/lora/400.css";
+import "@fontsource/lora/700.css";
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
- Replace the `typeface-lora` package with `@fontsource/lora`
- Only import the font styles that blaseball.com uses (i.e. weights 400 and 700, no italic styles), to fix inconsistencies
- Add CSS styling for the Shelled One (it's bound to show up in the library at some point)
- Fix styling for the Reader (`font-weight: 700`) and site announcements (`font-style: italic`) to match blaseball.com
- Fix Lōotcrates's name