### PR TITLE
Handle linebreaks in messages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -141,6 +141,14 @@ input[type=checkbox] {
   font-family: "Lora";
 }
 
+.plainlist {
+  padding: 0;
+}
+
+.plainlist > li {
+  list-style-type: none;
+}
+
 .feedList {
   padding: 0;
   background: var(--primary-color);

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -82,7 +82,9 @@ class Entry extends React.PureComponent {
           {dayStr}
         </div>
         <div className={entryText}>
-          {description}
+          <ul class="plainlist">
+            {description.split("\n").map((line) => (<li>{line}</li>))}
+          </ul>
         </div>
       </div>
     );


### PR DESCRIPTION
Currently Feedeck displays linebreaks in messages as spaces (most easily visible with decree narration or Lōotcrates' messages); this PR fixes that by wrapping entry text in an unordered list and splitting messages into lines.